### PR TITLE
Fix passing arguments

### DIFF
--- a/worlds/slowrelease/__init__.py
+++ b/worlds/slowrelease/__init__.py
@@ -5,7 +5,7 @@ def launch_client(*args):
     from CommonClient import gui_enabled
     if not gui_enabled:
         print(args)
-        launch(args)
+        launch(*args)
     launch_subprocess(launch, name="Slow Release Client", args=args)
 components.append(Component("Slow Release Client", "SlowReleaseClient", func=launch_client,
                             component_type=Type.CLIENT, supports_uri=True, game_name=None))


### PR DESCRIPTION
`args` is already a tuple and `launch()` expects each argument to be a CLI argument, so extract args so it parses correctly.

## What is this fixing or adding?

Fixes:
```python-traceback
Traceback (most recent call last):
  File "__startup__.py", line 133, in run
  File "console.py", line 25, in run
  File "Launcher.py", line 511, in <module>
  File "Launcher.py", line 490, in main
  File "Launcher.py", line 451, in run_component
  File "/Archipelago/custom_worlds/slowrelease.apworld/slowrelease/__init__.py", line 8, in launch_client
  File "/Archipelago/custom_worlds/slowrelease.apworld/slowrelease/Client.py", line 140, in launch
  File "urllib/parse.py", line 394, in urlparse
  File "urllib/parse.py", line 133, in _coerce_args
  File "urllib/parse.py", line 117, in _decode_args
  File "urllib/parse.py", line 117, in <genexpr>
AttributeError: 'tuple' object has no attribute 'decode'
```
Where `args == (('--nogui',),)` (when passed to `parsed_args`), but this commit changes it to `args == ('--nogui',)`.

## How was this tested?

Running `./ArchipelagoLauncher "Slow Release Client" -- --nogui`

## If this makes graphical changes, please attach screenshots.

Not applicable.